### PR TITLE
fix TypeError in format_chunksize, y-axis scale of knee-plot

### DIFF
--- a/LR-splitpipe/demultiplex.py
+++ b/LR-splitpipe/demultiplex.py
@@ -329,7 +329,7 @@ def main():
 	delete_input = args.delete_input
 
 	def format_chunksize(c):
-		if '**' in c:
+		if isinstance(c, str) and '**' in c:
 			i, j = c.split('**')
 			i = float(i)
 			j = float(j)

--- a/LR-splitpipe/plotting.py
+++ b/LR-splitpipe/plotting.py
@@ -131,6 +131,7 @@ def plot_knee_plot(df, oprefix, kind):
 			linewidth=2)
 	ax = plt.gca()
 	ax.set_xscale('log')
+	ax.set_yscale('log')
 	ax.set_xlabel('Ranked cells by # UMIs')
 	ax.set_ylabel('# UMIs (logscale)')
 	ax.set_title(kind)


### PR DESCRIPTION
Fix TypeError when chunksize is specified as int
```
File "/LR-splitpipe/LR-splitpipe/demultiplex.py", line 332, in format_chunksize
    if '**' in c:
TypeError: argument of type 'int' is not iterable
```